### PR TITLE
Remove broken badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 [![Release](https://jitpack.io/v/MarcinOrlowski/datetimetemplate.svg)](https://jitpack.io/#MarcinOrlowski/DateTimeTemplate)
-![Downloads](https://jitpack.io/v/MarcinOrlowski/DateTimeTemplate/month.svg)
-[![Dependency Status](https://dependencyci.com/github/MarcinOrlowski/DateTimeTemplate/badge)](https://dependencyci.com/github/MarcinOrlowski/DateTimeTemplate)
 
 DateTimeTemplate
 ================


### PR DESCRIPTION
The badge for <https://dependencyci.com/> is broken due to the company being bought by Tidelift 

https://jitpack.io/v/MarcinOrlowski/DateTimeTemplate/month.svg also seems to be broken, but https://jitpack.io/v/MarcinOrlowski/datetimetemplate.svg works fine so could be that month.svg support got removed from jitpack.io 